### PR TITLE
filter org grants by from/to organization name or description or grant tag

### DIFF
--- a/config/test.toml
+++ b/config/test.toml
@@ -9,3 +9,10 @@ port = 5432
 database = 'gnl_test'
 username = 'gnl'
 password = ''
+
+[google]
+client_id = 'GOOGLE_CLIENT_ID'
+client_secret = 'GOOGLE_CLIENT_SECRET'
+
+[auth]
+allowed_emails = 'good@user'

--- a/integration-tests/index.test.js
+++ b/integration-tests/index.test.js
@@ -151,7 +151,7 @@ test('sorts organization grants by date', async () => {
   instance.close();
 });
 
-test('filter organization grants funded/received by name', async () => {
+test('filter organization grants funded/received by description', async () => {
   const { uri, instance } = await createServerInstance();
 
   const res = await request(
@@ -188,6 +188,67 @@ query filterOrganizationGrants {
   instance.close();
 });
 
+test('filter organization grants funded/received by name', async () => {
+  const { uri, instance } = await createServerInstance();
+
+  const res = await request(
+    uri,
+    `
+query filterOrganizationGrants {
+  organization(id: 93) {
+    grantsFunded(
+      limit: 10,
+      orderByDirection: ASC,
+      orderBy: dateFrom,
+      textLike: { oToName: "test organization 8%" }
+    ) {
+      to { name }
+    }
+  }
+}
+`
+  );
+
+  expect(res).toEqual({
+    organization: {
+      grantsFunded: [
+        {
+          to: {
+            name: 'test organization 89',
+          },
+        },
+        {
+          to: {
+            name: 'test organization 88',
+          },
+        },
+        {
+          to: {
+            name: 'test organization 87',
+          },
+        },
+        {
+          to: {
+            name: 'test organization 86',
+          },
+        },
+        {
+          to: {
+            name: 'test organization 85',
+          },
+        },
+        {
+          to: {
+            name: 'test organization 84',
+          },
+        },
+      ],
+    },
+  });
+
+  instance.close();
+});
+
 test('stats', async () => {
   const { uri, instance } = await createServerInstance();
 
@@ -208,8 +269,8 @@ query homepage {
     stats: {
       totalNumOrgs: 100,
       totalNumGrants: 738,
-      totalGrantsDollars: 49800
-    }
+      totalGrantsDollars: 49800,
+    },
   });
 
   instance.close();

--- a/integration-tests/index.test.js
+++ b/integration-tests/index.test.js
@@ -249,6 +249,44 @@ query filterOrganizationGrants {
   instance.close();
 });
 
+test("list grant tags related to a specific organization's grants", async () => {
+  const { uri, instance } = await createServerInstance();
+
+  const res = await request(
+    uri,
+    `
+query organizationGrantTags {
+  organization(id: 92) {
+    organizationGrantTags {
+      name
+    }
+  }
+}
+`
+  );
+
+  expect(res).toEqual({
+    organization: {
+      organizationGrantTags: [
+        {
+          name: 'test grant tag 0',
+        },
+        {
+          name: 'test grant tag 1',
+        },
+        {
+          name: 'test grant tag 2',
+        },
+        {
+          name: 'test grant tag 3',
+        },
+      ],
+    },
+  });
+
+  instance.close();
+});
+
 test('stats', async () => {
   const { uri, instance } = await createServerInstance();
 

--- a/src/db/models/grantTag.ts
+++ b/src/db/models/grantTag.ts
@@ -88,10 +88,12 @@ export const grantTagArgs = ledgerListArgs(
 
 interface GrantTagResolverOptions {
   limitToGrantId: boolean;
+  limitToOrganizationId: boolean;
 }
 
 const defaultGrantTagResolverOptions = {
   limitToGrantId: false,
+  limitToOrganizationId: false,
 };
 
 export const grantTagResolver = (
@@ -107,6 +109,13 @@ export const grantTagResolver = (
   // Fetching only grant tags related to a specific grant
   if (resolverOpts.limitToGrantId) {
     where = `WHERE g.id=${escape(opts.dataValues.id)}`;
+  } else if (resolverOpts.limitToOrganizationId) {
+    where = `
+WHERE ggt.grant_id IN (
+  SELECT id FROM "grant" g WHERE g.from=${escape(opts.dataValues.id)}
+  UNION
+  SELECT id FROM "grant" g WHERE g.to=${escape(opts.dataValues.id)}
+)`;
   } else {
     where = uuid ? `WHERE gt.uuid = ${escape(uuid)}` : '';
   }

--- a/src/db/models/organization.ts
+++ b/src/db/models/organization.ts
@@ -28,6 +28,7 @@ import {
   OrganizationTagInstance,
   OrganizationTagAttributes,
 } from './organizationTag';
+import { GrantTagInstance, GrantTagAttributes } from './grantTag';
 import { Form990Instance, Form990Attributes } from './form990';
 import { BoardTermInstance, BoardTermAttributes } from './boardTerm';
 

--- a/src/db/models/organization.ts
+++ b/src/db/models/organization.ts
@@ -354,9 +354,9 @@ export const createGetOrganizationByIdDataloader = (
 
 export const createGetOrganizationByUuidDataloader = (
   db: Db
-): DataLoader<number, OrganizationInstance> => {
+): DataLoader<string, OrganizationInstance> => {
   return new DataLoader(
-    async (uuids: number[]): Promise<OrganizationInstance[]> => {
+    async (uuids: string[]): Promise<OrganizationInstance[]> => {
       const results = await db.sequelize.query(
         `SELECT o.*, ${specialCols(organizationSpecialFields, 'om').join(',')}
   FROM organization o

--- a/src/server.ts
+++ b/src/server.ts
@@ -174,6 +174,7 @@ export default function createServer(
       }),
       from: { type: GraphQLString },
       to: { type: GraphQLString },
+      amount: { type: GraphQLString }, // Ideally this would be GraphQLBigInt but it doesn't seem to work w/ mutation!
     },
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -157,7 +157,10 @@ export default function createServer(
       grantTags: {
         type: new GraphQLList(grantTagType),
         args: grantTagArgs,
-        resolve: grantTagResolver(db, { limitToGrantId: true }),
+        resolve: grantTagResolver(db, {
+          limitToGrantId: true,
+          limitToOrganizationId: false,
+        }),
       },
       amount: { type: GraphQLBigInt },
     },
@@ -246,6 +249,14 @@ export default function createServer(
         type: new GraphQLList(organizationTagType),
         args: organizationTagArgs,
         resolve: organizationTagResolver(db, { limitToOrganizationId: true }),
+      },
+      organizationGrantTags: {
+        type: new GraphQLList(grantTagType),
+        args: grantTagArgs,
+        resolve: grantTagResolver(db, {
+          limitToGrantId: false,
+          limitToOrganizationId: true,
+        }),
       },
     },
   });


### PR DESCRIPTION
this PR adds the features we need to move forward with the organization grants page's grants received/funded list filters. i think the integration tests show how it works pretty well!

also it adds a test for the add grant mutation.