### PR TITLE
add related grants field to grant

### DIFF
--- a/integration-tests/index.test.js
+++ b/integration-tests/index.test.js
@@ -435,3 +435,76 @@ mutation addstuff {
 
   instance.close();
 });
+
+test('related grants', async () => {
+  const { uri, instance } = await createServerInstance();
+
+  // Get a grant ID
+  const grantId = await request(
+    uri,
+    `
+query grantId {
+  organizations(
+    nameLike: "%Test Organization 97%"
+    limit: 1
+    orderBy: countGrantsTo
+    orderByDirection: DESC
+  ) {
+    grantsFunded(limit: 1) {
+      uuid
+    }
+  }
+}
+  `
+  );
+
+  // Now find some related grantsa
+  const res = await request(
+    uri,
+    `
+query grant {
+  grant(uuid: "${grantId.organizations[0].grantsFunded[0].uuid}") {
+    relatedFrom(limit: 3) {
+      to {
+        name
+      }
+      from {
+        name
+      }
+    }
+  }
+}
+  `
+  );
+
+  expect(res).toEqual({
+    grant: {
+      relatedFrom: [
+        {
+          to: {
+            name: 'test organization 96',
+          },
+          from: {
+            name: 'test organization 97',
+          },
+        },
+        {
+          to: {
+            name: 'test organization 95',
+          },
+          from: {
+            name: 'test organization 97',
+          },
+        },
+        {
+          to: {
+            name: 'test organization 94',
+          },
+          from: {
+            name: 'test organization 97',
+          },
+        },
+      ],
+    },
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,25 @@ export default function createServer(
     fields: attributeFields(db.Organization, { exclude: ['id'] }),
   });
 
+  const shallowGrantType = new GraphQLObjectType({
+    name: 'ShallowGrant',
+    description: 'A grant, without tags or related org grants',
+    fields: {
+      ...attributeFields(db.Grant, { exclude: ['id'] }),
+      from: {
+        type: shallowOrganizationType,
+        args: organizationArgs,
+        resolve: singleOrganizationResolver(opts => opts.get('from')),
+      },
+      to: {
+        type: shallowOrganizationType,
+        args: organizationArgs,
+        resolve: singleOrganizationResolver(opts => opts.get('to')),
+      },
+      amount: { type: GraphQLBigInt },
+    },
+  });
+
   const organizationTagType = new GraphQLObjectType({
     name: 'OrganizationTag',
     description: 'Tag associated with an organization',
@@ -163,6 +182,16 @@ export default function createServer(
         }),
       },
       amount: { type: GraphQLBigInt },
+      relatedFrom: {
+        type: new GraphQLList(shallowGrantType),
+        args: grantArgs,
+        resolve: grantResolver(db, opts => `g.from=${opts.get('from')}`),
+      },
+      relatedTo: {
+        type: new GraphQLList(shallowGrantType),
+        args: grantArgs,
+        resolve: grantResolver(db, opts => `g.to=${opts.get('to')}`),
+      },
     },
   });
 


### PR DESCRIPTION
the new `ShallowGrant` type limits the potential damage from nested queries. see integration test for a usage example.